### PR TITLE
feat: 提供\swufeversion等描述项目信息的命令

### DIFF
--- a/build.lua
+++ b/build.lua
@@ -21,9 +21,18 @@ packtdszip = true
 function update_tag(file, content, tagname, tagdate)
   tagdate = string.gsub(tagdate, "%-", "/")
   if string.match(file, "%.dtx$") then
-    return string.gsub(content,
+    -- 替换ProvidesFile
+    content = string.gsub(content,
       "\n%[%d%d%d%d/%d%d/%d%d %d+%.%d+%.%d+[%w%-%.]* ([%w%s]+)%]\n",
       "\n[" .. tagdate .. " " .. tagname .. " %1]\n")
+    -- 替换\swufeversion
+    content = string.gsub(content,
+      "(\n\\newcommand{\\swufeversion}{)[%w%.%-]*(})",
+      "%1" .. tagname .. "%2")
+    -- 替换\swufeversion
+    return string.gsub(content,
+      "(\n\\newcommand{\\swufedate}{)%d%d%d%d/%d%d/%d%d(})",
+      "%1" .. tagdate .. "%2")
   end
   return content
 end

--- a/swufedoc.dtx
+++ b/swufedoc.dtx
@@ -80,6 +80,7 @@
 % \cs{SwufeThesis}会打印“\SwufeThesis”，可以作为本项目的标识。
 %    \begin{macrocode}
 \def\SwufeThesis{\textsc{Swufe\-Thesis}}
+\let\swufethesis\SwufeThesis
 %    \end{macrocode}
 % \end{macro}
 % \subsection{字体设定}

--- a/swufethesis-doc.tex
+++ b/swufethesis-doc.tex
@@ -224,6 +224,14 @@ of \textbf{F}inance and \textbf{E}conomics \LaTeX\ \textbf{Thesis} Template)
   \end{acknowledgments}
 \end{latex}
 
+\subsection{杂项}
+\DescribeMacro{\SwufeThesis}
+\DescribeMacro{\swufethesis}
+\DescribeMacro{\swufeversion}
+\DescribeMacro{\swufedate}
+\cs{SwufeThesis}或者\cs{swufethesis}会打印项目标识\SwufeThesis{}，
+而 \cs{swufeversion}与 \cs{swufedate}会打印当前的版本和发布日期（YYYY/MM/DD）。
+
 \section{致谢}
 这个项目在开发的过程借鉴了许多 \href{https://github.com/tuna/thuthesis}{tuna/thuthesis}
 的设计，也参考了 \href{https://github.com/stone-zeng/fduthesis}{stone-zeng/fduthesis}、

--- a/swufethesis.dtx
+++ b/swufethesis.dtx
@@ -1204,4 +1204,22 @@
   degree-type = academic,
 }
 %    \end{macrocode}
+%
+% \subsection{其他}
+% 定义一些与项目本身有关的命令。
+% \begin{macro}{\SwufeThesis}
+% \cs{SwufeThesis}与\cs{swufethesis}打印\swufethesis{}，可以作为项目的标识。
+%    \begin{macrocode}
+\newcommand{\SwufeThesis}{\textsc{Swufe\-Thesis}}
+\let\swufethesis\SwufeThesis
+%    \end{macrocode}
+% \end{macro}
+%
+% \begin{macro}{\swufeversion}
+% \cs{swufeversion}打印当前版本，\cs{swufedate}打印发布日期。
+%    \begin{macrocode}
+\newcommand{\swufeversion}{1.0.0-alpha.0}
+\newcommand{\swufedate}{2021/03/15}
+%    \end{macrocode}
+% \end{macro}
 % \Finale


### PR DESCRIPTION
提供`\swufethesis`以打印项目标识，`\swufeversion`
和`\swufedate`打印版本与发布日期。
